### PR TITLE
Fix the typings to enable TS import

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -2,7 +2,7 @@ import { ErrorObject } from 'ajv';
 
 declare var betterAjvErrors: betterAjvErrors.IBetterAjvErrors;
 
-export default betterAjvErrors;
+export = betterAjvErrors;
 export as namespace betterAjvErrors;
 
 declare namespace betterAjvErrors {


### PR DESCRIPTION
After the change to typings, it's now impossible to `import * as BAE` in Typescript, but it is the only way to use the library.

With the current version `import BAE from ...` TS is happy, but after compilation to JS the import is not a constructor (tsc compiles the default import in a different way).

@torifat hmm?