### PR TITLE
Properly unescape json pointers

### DIFF
--- a/src/json/__fixtures__/scenario-5.json
+++ b/src/json/__fixtures__/scenario-5.json
@@ -1,0 +1,10 @@
+{
+  "foo": {
+    "/some/path": {
+      "value": 1
+    },
+    "~some~path": {
+      "value": 2
+    }
+  }
+}

--- a/src/json/__tests__/__snapshots__/index.js.snap
+++ b/src/json/__tests__/__snapshots__/index.js.snap
@@ -169,3 +169,45 @@ Object {
   "value": "foo",
 }
 `;
+
+exports[`JSON can work with unescaped JSON pointers with ~0 1`] = `
+Object {
+  "loc": Object {
+    "end": Object {
+      "column": 17,
+      "line": 7,
+      "offset": 93,
+    },
+    "source": null,
+    "start": Object {
+      "column": 16,
+      "line": 7,
+      "offset": 92,
+    },
+  },
+  "raw": "2",
+  "type": "Literal",
+  "value": 2,
+}
+`;
+
+exports[`JSON can work with unescaped JSON pointers with ~1 1`] = `
+Object {
+  "loc": Object {
+    "end": Object {
+      "column": 17,
+      "line": 4,
+      "offset": 49,
+    },
+    "source": null,
+    "start": Object {
+      "column": 16,
+      "line": 4,
+      "offset": 48,
+    },
+  },
+  "raw": "1",
+  "type": "Literal",
+  "value": 1,
+}
+`;

--- a/src/json/__tests__/index.js
+++ b/src/json/__tests__/index.js
@@ -42,4 +42,20 @@ describe('JSON', () => {
     const jsonAst = parse(rawJson, { loc: true });
     expect(getDecoratedDataPath(jsonAst, '/arr/4')).toMatchSnapshot();
   });
+
+  it('can work with unescaped JSON pointers with ~1', async () => {
+    const rawJson = await loadScenario(5);
+    const jsonAst = parse(rawJson, { loc: true });
+    expect(
+      getMetaFromPath(jsonAst, '/foo/~1some~1path/value')
+    ).toMatchSnapshot();
+  });
+
+  it('can work with unescaped JSON pointers with ~0', async () => {
+    const rawJson = await loadScenario(5);
+    const jsonAst = parse(rawJson, { loc: true });
+    expect(
+      getMetaFromPath(jsonAst, '/foo/~0some~0path/value')
+    ).toMatchSnapshot();
+  });
 });

--- a/src/json/get-meta-from-path.js
+++ b/src/json/get-meta-from-path.js
@@ -1,10 +1,15 @@
+import { unescapeJsonPointer } from 'ajv/lib/compile/util';
+
 export default function getMetaFromPath(
   jsonAst,
   dataPath,
   isIdentifierLocation
 ) {
   // TODO: Handle json pointer escape notation and better error handling
-  const pointers = dataPath.split('/').slice(1);
+  const pointers = dataPath
+    .split('/')
+    .slice(1)
+    .map(unescapeJsonPointer);
   const lastPointerIndex = pointers.length - 1;
   return pointers.reduce((obj, pointer, idx) => {
     switch (obj.type) {


### PR DESCRIPTION
AJV escapes ~ and / with ~0 and ~1 respectively, so we should unescape it.