### PR TITLE
Fix error list output for `cli` format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default (schema, data, errors, options = {}) => {
   });
 
   if (format === 'cli') {
-    return customErrors.map(customErrorToText).join();
+    return customErrors.map(customErrorToText).join('\n\n');
   } else {
     return customErrors.map(customErrorToStructure);
   }


### PR DESCRIPTION
Currently, error messages are incorrectly joined with a comma.

This fixes it so that they are joined with two newlines.

### Before

![incorrect output](https://user-images.githubusercontent.com/270491/40235912-68aefc98-5ab4-11e8-8cf4-79b6adc1ef1d.png)

### After

![correct output](https://user-images.githubusercontent.com/270491/40235991-b9daba08-5ab4-11e8-9742-208e66a6cf41.png)

---

See also: https://github.com/atlassian/better-ajv-errors/pull/21

Co-Authored-By: @lahmatiy

---

**P.S.:** Since this is now the main repository for this project, can you enable issues on this repository?

review?(@torifat)